### PR TITLE
3 updates: accessAtIndex:+example; WAHtmlCanvas->SBSHtmlCanvas; defaultSortBlock to handle nil values

### DIFF
--- a/BootstrapTable-Core/SBSTableColumn.class.st
+++ b/BootstrapTable-Core/SBSTableColumn.class.st
@@ -59,7 +59,7 @@ SBSTableColumn >> footerForData [
 	self hasFooter ifFalse: [^nil].
 	self hasRenderBlock ifFalse: [^super footerForData].
 
-	^WAHtmlCanvas builder
+	^SBSHtmlCanvas builder
 		fullDocument: false;
 		render: [ :html |self renderBlock cull: html cull: footerBlock value]
 ]
@@ -114,7 +114,7 @@ SBSTableColumn >> handleFooterCallback [
 		response 
 			contentType: self application contentType;
 			nextPutAll: 
-				(WAHtmlCanvas builder
+				(SBSHtmlCanvas builder
 					fullDocument: false;
 					render: 
 						[ :html |
@@ -134,7 +134,7 @@ SBSTableColumn >> handleFormatterCallbackForRowId: anInteger [
 			response 
 				contentType: self application contentType;
 				nextPutAll: 
-					(WAHtmlCanvas builder
+					(SBSHtmlCanvas builder
 						fullDocument: false;
 						render: 
 							[ :html |

--- a/BootstrapTable-Core/SBSTableSingleColumn.class.st
+++ b/BootstrapTable-Core/SBSTableSingleColumn.class.st
@@ -177,7 +177,7 @@ SBSTableSingleColumn >> handleFooterCallback [
 		response 
 			contentType: self application contentType;
 			nextPutAll: 
-				(WAHtmlCanvas builder
+				(SBSHtmlCanvas builder
 					fullDocument: false;
 					render: 
 						[ :html |

--- a/BootstrapTable-Core/SBSTableSingleColumn.class.st
+++ b/BootstrapTable-Core/SBSTableSingleColumn.class.st
@@ -23,6 +23,14 @@ SBSTableSingleColumn >> accessAt: aSymbol [
 ]
 
 { #category : 'accessing' }
+SBSTableSingleColumn >> accessAtIndex: anInteger [
+
+    self 
+        fieldName: ('field', anInteger asString);
+        getContentsBlock: [ :obj | obj at: anInteger]
+]
+
+{ #category : 'accessing' }
 SBSTableSingleColumn >> accessor: aSymbol [
 
 	"Configure the receiver to display the value answered by a row object to the message aSymbol"

--- a/BootstrapTable-Core/SBSTableSingleColumn.class.st
+++ b/BootstrapTable-Core/SBSTableSingleColumn.class.st
@@ -100,7 +100,16 @@ SBSTableSingleColumn >> contentFromRow: anObject [
 { #category : 'constants' }
 SBSTableSingleColumn >> defaultSortBlock [
 
-	^[ :a :b | (self contentFromRow: a) <= (self contentFromRow: b)]
+	"to handle nil values - nil values will precede other values in code below "
+
+	^ [ :a :b | 
+		(self contentFromRow: a) 
+			ifNil: [ true ]
+		 	ifNotNil: [  (self contentFromRow: b) 
+				ifNil: [ false ] 
+				ifNotNil: [ (self contentFromRow: a) <= (self contentFromRow: b)] 
+			] 
+		]
 ]
 
 { #category : 'accessing' }

--- a/BootstrapTable-Examples/SBSBootstrapTableAccessUsingIndexExample.class.st
+++ b/BootstrapTable-Examples/SBSBootstrapTableAccessUsingIndexExample.class.st
@@ -1,0 +1,52 @@
+Class {
+	#name : 'SBSBootstrapTableAccessUsingIndexExample',
+	#superclass : 'SBSBootstrapTableExample',
+	#category : 'BootstrapTable-Examples',
+	#package : 'BootstrapTable-Examples'
+}
+
+{ #category : 'accessing' }
+SBSBootstrapTableAccessUsingIndexExample class >> exampleName [
+
+	^'Access using Index'
+]
+
+{ #category : 'accessing' }
+SBSBootstrapTableAccessUsingIndexExample class >> ordering [
+
+	^ 6
+]
+
+{ #category : 'initialize-release' }
+SBSBootstrapTableAccessUsingIndexExample >> createTable [
+
+	^SBSTable new
+		list: (Array with: #(1 2 3) with: #(4 5 6) with: #(7 8 9)) ;
+		addColumn: 
+			(SBSTableColumn new
+				label: 'Var-1';
+				accessAtIndex: 1;
+				yourself);
+		addColumn: 
+			(SBSTableColumn new
+				label: 'Var-2';
+				accessAtIndex: 2;
+				yourself);
+		addColumn: 
+			(SBSTableColumn new
+				label: 'Var-3';
+				accessAtIndex: 3;
+				renderBlock: [ :html :price | html text: ('$', price greaseString)];
+				yourself);
+		yourself
+]
+
+{ #category : 'rendering' }
+SBSBootstrapTableAccessUsingIndexExample >> renderDescriptionOn: html [
+
+	html text: 'Use '.
+	html code with: 'accessAtIndex:'.
+	html text: ' to use table row data in the form of '.
+	html code with: 'Arrays'
+
+]

--- a/BootstrapTable-Examples/SBSBootstrapTableApplicationExample.class.st
+++ b/BootstrapTable-Examples/SBSBootstrapTableApplicationExample.class.st
@@ -86,7 +86,7 @@ SBSBootstrapTableApplicationExample >> createTable [
 				isSortable: true;
 				alignRight;
 				footerIsTotal;
-				renderBlock: [ :html :price | html text: ('$', price displayString)];
+				renderBlock: [ :html :price | html text: ('$', price greaseString)];
 				yourself);
 		addColumn: 
 			(SBSTableColumn new


### PR DESCRIPTION
attaching 3 updates
1. included the code for accessAtIndex: (as suggested) with an example
2. changed WAHtmlCanvas to SBSHtmlCanvas. (as this package is using https://github.com/astares/Seaside-Bootstrap5 and some extensions in SBSHtmlCanvas would be required for fuller use. Also maybe you can put the canvas class at a single location so that future modification or usage of a custom canvas class is easier).
3. changed defaultSortBlock to handle 'nil' values which will be placed first when sorting. (I really dont know the convention for sortBlock but felt this is a good inclusion since nil's do come up and dont foresee any adverse impact)

pls do take a look to include / modify / improve / confirm to convention - particularly the deafultSortBlock   